### PR TITLE
Repos page, minor logic && style updates

### DIFF
--- a/src/components/Project/Project.tsx
+++ b/src/components/Project/Project.tsx
@@ -81,7 +81,8 @@ const Project: FC<IProjectProps> = ({ title, description, links, stack }) => {
                     variant="outline"
                     color={theme.colorScheme === 'dark' ? 'yellow' : 'violet'}
                     key={i}
-                    ml={10}
+                    ml={theme.breakpoints.xs ? 0 : 10}
+                    mr={theme.breakpoints.xs ? 10 : 0}
                   >
                     {item}
                   </Badge>

--- a/src/components/Repo/Repo.styles.ts
+++ b/src/components/Repo/Repo.styles.ts
@@ -1,6 +1,8 @@
 import { createStyles } from '@mantine/core'
 
 export default createStyles((theme) => ({
+  card: { minHeight: 160 },
+
   link: {
     all: 'unset',
     cursor: 'pointer',

--- a/src/components/Repo/Repo.tsx
+++ b/src/components/Repo/Repo.tsx
@@ -2,17 +2,18 @@ import React, { FC } from 'react'
 import {
   Card,
   Group,
+  Stack,
   useMantineTheme,
-  Title,
   Anchor,
   Text,
+  Title,
 } from '@mantine/core'
 import { motion } from 'framer-motion'
 import { Star } from 'tabler-icons-react'
 import { IRepoProps } from '../../interfaces/Repo.interface'
 import useStyles from './Repo.styles'
 
-const Repo: FC<IRepoProps> = ({ title, starCount, url }) => {
+const Repo: FC<IRepoProps> = ({ title, description, url, starCount }) => {
   const { classes } = useStyles()
   const theme = useMantineTheme()
 
@@ -21,23 +22,24 @@ const Repo: FC<IRepoProps> = ({ title, starCount, url }) => {
       whileHover={{ scale: 1.01 }}
       transition={{ type: 'spring', stiffness: 100, damping: 10 }}
     >
-      <Card withBorder radius="md" p="sm">
-        <Group position="apart" direction="column">
-          <Anchor href={url} target="_blank" className={classes.link}>
-            <Title order={5} mb="sm" color="red">
-              {title}
-            </Title>
-          </Anchor>
-          <Group spacing={4}>
-            <Text size="sm">{starCount}</Text>
-            <Star
-              size={20}
-              strokeWidth={2}
-              color={theme.colorScheme === 'dark' ? '#ffd43b' : '#808080'}
-            />
-          </Group>
-        </Group>
-      </Card>
+      <Anchor href={url} target="_blank" className={classes.link}>
+        <Card withBorder radius="md" className={classes.card}>
+          <Stack>
+            <Title order={5}>{title}</Title>
+            <Text size="sm" my="md">
+              {description}
+            </Text>
+            <Group spacing={4}>
+              <Text size="sm">{starCount}</Text>
+              <Star
+                size={20}
+                strokeWidth={2}
+                color={theme.colorScheme === 'dark' ? '#ffd43b' : '#FFA500'}
+              />
+            </Group>
+          </Stack>
+        </Card>
+      </Anchor>
     </motion.div>
   )
 }

--- a/src/interfaces/Repo.interface.ts
+++ b/src/interfaces/Repo.interface.ts
@@ -1,5 +1,6 @@
 export interface IRepoProps {
   title: string
-  starCount: number
+  description: string
   url: string
+  starCount: number
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,9 @@
+const token_endpoint = 'https://api.github.com/users/aycanogut/repos'
+
+export const getRepos = async () => {
+  const response = await fetch(token_endpoint, {
+    method: 'GET',
+  })
+
+  return response.json()
+}

--- a/src/pages/projects/repos/index.tsx
+++ b/src/pages/projects/repos/index.tsx
@@ -1,0 +1,51 @@
+import { FC } from 'react'
+import { Grid, Title } from '@mantine/core'
+import Layout from '../../../components/Layout/Layout'
+import Repo from '../../../components/Repo/Repo'
+import CustomLoader from '../../../components/CustomLoader/CustomLoader'
+import Error from '../../../components/Error/Error'
+import { getRepos } from '../../../lib/github'
+import { IRepoProps } from '../../../interfaces/Repo.interface'
+
+const Repos: FC<IRepoProps> = ({ repos }: any) => {
+  if (!repos) return <Error />
+
+  return (
+    <Layout>
+      <Title order={1} mb={30}>
+        Repos
+      </Title>
+      <Grid gutter="lg" grow>
+        {!repos ? (
+          <CustomLoader />
+        ) : (
+          repos &&
+          repos
+            .sort((a, b) => b.stargazers_count - a.stargazers_count)
+            .map((repo: any) => (
+              <Grid.Col span={12} xs={6} sm={4} key={repo.id}>
+                <Repo
+                  title={repo.name}
+                  description={repo.description}
+                  url={repo.html_url}
+                  starCount={repo.stargazers_count}
+                />
+              </Grid.Col>
+            ))
+        )}
+      </Grid>
+    </Layout>
+  )
+}
+
+export async function getStaticProps() {
+  const repos = await getRepos()
+
+  return {
+    props: {
+      repos,
+    },
+  }
+}
+
+export default Repos


### PR DESCRIPTION
Add `Repos` page.
Add fetcher for Github API.
Update `Repo` component as a clickable card.
Update `Repo` interface.
Update `Repo` components height for equalize all cards on layout.
Fix `Project` spacing bug on responsive.